### PR TITLE
BugFix RedirectKeeper always comparing with the MasterLanguage.

### DIFF
--- a/Epicweb.Optimizely.RedirectManager/RedirectKeeper.cs
+++ b/Epicweb.Optimizely.RedirectManager/RedirectKeeper.cs
@@ -40,7 +40,7 @@ namespace Epicweb.Optimizely.RedirectManager
             if (ContentReference.IsNullOrEmpty(e.ContentLink))
                 return; //new page
 
-            PageData oldPage = GetLastVersion(e.ContentLink.ToPageReference(), (e.Content as ILocalizable).MasterLanguage.TwoLetterISOLanguageName) as PageData;
+            PageData oldPage = GetLastVersion(e.ContentLink.ToPageReference(), (e.Content as ILocalizable).Language.TwoLetterISOLanguageName) as PageData;
 
             if (oldPage != null && oldPage.URLSegment != (e.Content as PageData).URLSegment)
                 LogChange(oldPage, true);


### PR DESCRIPTION
RedirectKeeper fix: It now compares the language of the page with the current language instead of always comparing it with the MasterLanguage.